### PR TITLE
Add Azerbaijani translations

### DIFF
--- a/azaccounting/admin/setup.php
+++ b/azaccounting/admin/setup.php
@@ -43,7 +43,7 @@ print_fiche_titre($langs->trans("AzAccountingSetup"), '', 'object_azaccounting.p
 print '<div class="fichecenter">';
 print '<div class="underbanner clearboth"></div>';
 
-print 'Azərbaycan Mühasibatlıq modulunun tənzimləmə səhifəsi. Bu funksiya hələ hazırlanır.';
+print $langs->trans("AzAccountingSetupIntro");
 
 // Placeholder for future configuration form
 // print '<form action="'.$_SERVER["PHP_SELF"].'" method="POST">';

--- a/azaccounting/langs/az_AZ/azaccounting.lang
+++ b/azaccounting/langs/az_AZ/azaccounting.lang
@@ -1,2 +1,4 @@
 ModuleAzAccountingDesc=Azərbaycan Mühasibatlığı Modulu
 AzAccounting=Azərbaycanca Mühasibatlıq
+AzAccountingSetup=Azərbaycanca Mühasibatlıq Tənzimləmələri
+AzAccountingSetupIntro=Azərbaycan Mühasibatlıq modulunun tənzimləmə səhifəsi. Bu funksiya hələ hazırlanır.


### PR DESCRIPTION
## Summary
- translate admin labels to Azerbaijani
- use translation string in setup page

## Testing
- `php -l azaccounting/admin/setup.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852bcf1cad48324a0f6ac39f8d77782