### PR TITLE
Add AzAccounting payroll module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# dolibar-module
+# Dolibarr Modules
+
+Bu repozitoriyada Dolibarr ERP/CRM ucun modullar toplusu saxlanilir. `azaccounting` modulu Azərbaycan qanunvericiliyinə uyğun əməkhaqqı və vergi hesablamalarını nümunə kimi təqdim edir.

--- a/doc/azaccounting_spec.md
+++ b/doc/azaccounting_spec.md
@@ -1,0 +1,11 @@
+# AzAccounting Modulunun Spesifikasiyasi
+
+Bu sənəd modulun əsas funksiyalarini qısa şəkildə təsvir edir.
+
+* **llx_az_employee** – əməkdaşların siyahısı
+* **llx_az_payroll** – hesablanmış əməkhaqqı məlumatları
+* **llx_az_taxconfig** – vergi faizlərinin saxlanılması
+* **accounting.class.php** – vergi hesablamaları üçün metodlar
+* **payroll.class.php** – əməkhaqqı əməliyyatlarının idarə edilməsi
+* **card.php** – əməkhaqqının hesablanması üçün forma
+* **list.php** – hesabatların siyahısı

--- a/htdocs/custom/azaccounting/admin/setup.php
+++ b/htdocs/custom/azaccounting/admin/setup.php
@@ -1,0 +1,34 @@
+<?php
+require '../../main.inc.php';
+require_once DOL_DOCUMENT_ROOT.'/custom/azaccounting/class/accounting.class.php';
+
+$langs->load('azaccounting@azaccounting');
+$action = GETPOST('save', 'alpha');
+
+$accounting = new Accounting($db);
+$cfg = $accounting->getTaxConfig();
+
+if ($action === 'save') {
+    $income = price2num(GETPOST('income_tax_rate', 'alpha'));
+    $dsmf = price2num(GETPOST('dsmf_rate', 'alpha'));
+    $db->begin();
+    $db->query("DELETE FROM llx_az_taxconfig");
+    $sql = "INSERT INTO llx_az_taxconfig(income_tax_rate,dsmf_rate) VALUES (".$income.",".$dsmf.")";
+    $db->query($sql);
+    $db->commit();
+    header('Location: setup.php');
+    exit;
+}
+
+llxHeader('', $langs->trans('AzAccountingSetup'));
+
+print '<form method="post" action="'.$_SERVER['PHP_SELF'].'">';
+print '<table class="noborder">';
+print '<tr class="liste_titre"><th colspan="2">'.$langs->trans('Vergi Nizamlamalari').'</th></tr>';
+print '<tr><td>Gəlir vergisi (%)</td><td><input type="text" name="income_tax_rate" value="'.dol_escape_htmltag($cfg->income_tax_rate).'"></td></tr>';
+print '<tr><td>DSMF (%)</td><td><input type="text" name="dsmf_rate" value="'.dol_escape_htmltag($cfg->dsmf_rate).'"></td></tr>';
+print '</table>';
+print '<div class="center"><input type="submit" class="button" name="save" value="'.$langs->trans('Yadda saxla').'"></div>';
+print '</form>';
+
+llxFooter();

--- a/htdocs/custom/azaccounting/card.php
+++ b/htdocs/custom/azaccounting/card.php
@@ -1,0 +1,36 @@
+<?php
+require '../main.inc.php';
+require_once DOL_DOCUMENT_ROOT.'/custom/azaccounting/class/payroll.class.php';
+
+$langs->load('azaccounting@azaccounting');
+$action = GETPOST('calc', 'alpha');
+
+$payroll = new Payroll($db);
+$res = $db->query("SELECT rowid, firstname, lastname FROM llx_az_employee WHERE active=1");
+
+if ($action) {
+    $employee = GETPOST('employee', 'int');
+    $gross = price2num(GETPOST('gross', 'alpha'));
+    $date = GETPOST('pay_date', 'alpha');
+    $payroll->addPayroll($employee, $gross, $date);
+    header('Location: list.php');
+    exit;
+}
+
+llxHeader('', $langs->trans('Payroll'));
+
+print '<form method="post" action="'.$_SERVER['PHP_SELF'].'">';
+print '<input type="hidden" name="calc" value="1">';
+print '<table class="border">';
+print '<tr><td>Əməkdaş</td><td><select name="employee">';
+while ($res && ($obj = $db->fetch_object($res))) {
+    print '<option value="'.$obj->rowid.'">'.$obj->firstname.' '.$obj->lastname.'</option>';
+}
+print '</select></td></tr>';
+print '<tr><td>Məbləğ</td><td><input type="text" name="gross"></td></tr>';
+print '<tr><td>Tarix</td><td><input type="date" name="pay_date" value="'.dol_print_date(dol_now(),'day').'"></td></tr>';
+print '</table>';
+print '<div class="center"><input type="submit" class="button" value="'.$langs->trans('Hesabla').'"></div>';
+print '</form>';
+
+llxFooter();

--- a/htdocs/custom/azaccounting/class/accounting.class.php
+++ b/htdocs/custom/azaccounting/class/accounting.class.php
@@ -1,0 +1,30 @@
+<?php
+class Accounting
+{
+    /** @var \DoliDB */
+    public $db;
+
+    public function __construct($db)
+    {
+        $this->db = $db;
+    }
+
+    public function getTaxConfig()
+    {
+        $sql = "SELECT income_tax_rate, dsmf_rate FROM llx_az_taxconfig LIMIT 1";
+        $res = $this->db->query($sql);
+        if ($res && $this->db->num_rows($res)) {
+            return $this->db->fetch_object($res);
+        }
+        return (object)array('income_tax_rate' => 0, 'dsmf_rate' => 0);
+    }
+
+    public function computeTaxes($gross)
+    {
+        $cfg = $this->getTaxConfig();
+        $income_tax = $gross * $cfg->income_tax_rate / 100;
+        $dsmf = $gross * $cfg->dsmf_rate / 100;
+        $net = $gross - $income_tax - $dsmf;
+        return array('income_tax' => $income_tax, 'dsmf' => $dsmf, 'net' => $net);
+    }
+}

--- a/htdocs/custom/azaccounting/class/payroll.class.php
+++ b/htdocs/custom/azaccounting/class/payroll.class.php
@@ -1,0 +1,39 @@
+<?php
+require_once __DIR__ . '/accounting.class.php';
+
+class Payroll
+{
+    /** @var \DoliDB */
+    public $db;
+    /** @var Accounting */
+    public $accounting;
+
+    public function __construct($db)
+    {
+        $this->db = $db;
+        $this->accounting = new Accounting($db);
+    }
+
+    public function addPayroll($employeeId, $gross, $date)
+    {
+        $taxes = $this->accounting->computeTaxes($gross);
+        $sql = "INSERT INTO llx_az_payroll(fk_employee, pay_date, gross, income_tax, dsmf, net)";
+        $sql .= " VALUES(" . ((int)$employeeId) . ", '" . $this->db->escape($date) . "'," . ((float)$gross) . ",";
+        $sql .= ((float)$taxes['income_tax']) . "," . ((float)$taxes['dsmf']) . "," . ((float)$taxes['net']) . ")";
+        return $this->db->query($sql);
+    }
+
+    public function getPayrolls()
+    {
+        $sql = "SELECT p.rowid, p.pay_date, e.lastname, e.firstname, p.gross, p.income_tax, p.dsmf, p.net";
+        $sql .= " FROM llx_az_payroll as p";
+        $sql .= " LEFT JOIN llx_az_employee as e ON p.fk_employee = e.rowid";
+        $sql .= " ORDER BY p.pay_date DESC";
+        $res = $this->db->query($sql);
+        $list = array();
+        while ($res && ($obj = $this->db->fetch_object($res))) {
+            $list[] = $obj;
+        }
+        return $list;
+    }
+}

--- a/htdocs/custom/azaccounting/langs/az_AZ/azaccounting.lang
+++ b/htdocs/custom/azaccounting/langs/az_AZ/azaccounting.lang
@@ -1,0 +1,6 @@
+AzAccountingSetup=Modul nizamlamalari
+Vergi Nizamlamalari=Vergi nizamlamaları
+Yadda saxla=Yadda saxla
+Payroll=Əmək haqqı hesabla
+PayrollList=Əmək haqqı siyahısı
+Hesabla=Hesabla

--- a/htdocs/custom/azaccounting/list.php
+++ b/htdocs/custom/azaccounting/list.php
@@ -1,0 +1,27 @@
+<?php
+require '../main.inc.php';
+require_once DOL_DOCUMENT_ROOT.'/custom/azaccounting/class/payroll.class.php';
+
+$langs->load('azaccounting@azaccounting');
+$payroll = new Payroll($db);
+$records = $payroll->getPayrolls();
+
+llxHeader('', $langs->trans('PayrollList'));
+
+print '<table class="noborder">';
+print '<tr class="liste_titre">';
+print '<th>Tarix</th><th>Əməkdaş</th><th>Məbləğ</th><th>Gəlir vergisi</th><th>DSMF</th><th>Xalis</th>';
+print '</tr>';
+foreach ($records as $rec) {
+    print '<tr>';
+    print '<td>'.dol_print_date($db->jdate($rec->pay_date),'day').'</td>';
+    print '<td>'.$rec->firstname.' '.$rec->lastname.'</td>';
+    print '<td>'.$rec->gross.'</td>';
+    print '<td>'.$rec->income_tax.'</td>';
+    print '<td>'.$rec->dsmf.'</td>';
+    print '<td>'.$rec->net.'</td>';
+    print '</tr>';
+}
+print '</table>';
+
+llxFooter();

--- a/htdocs/custom/azaccounting/modAzAccounting.class.php
+++ b/htdocs/custom/azaccounting/modAzAccounting.class.php
@@ -1,0 +1,36 @@
+<?php
+require_once DOL_DOCUMENT_ROOT . '/core/modules/DolibarrModules.class.php';
+
+class modAzAccounting extends DolibarrModules
+{
+    public function __construct($db)
+    {
+        global $langs;
+        $this->db = $db;
+        $this->numero = 500000;
+        $this->rights_class = 'azaccounting';
+        $this->family = 'az';
+        $this->name = preg_replace('/^mod/', '', get_class($this));
+        $this->description = "Azərbaycan uçotu modulu";
+        $this->version = '1.0';
+        $this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);
+        $this->picto = 'generic';
+        $this->module_parts = array();
+        $this->dirs = array('/azaccounting/temp');
+        $this->config_page_url = array('setup.php@azaccounting');
+
+        $this->rights = array();
+        $r = 0;
+        $this->rights[$r][0] = 5001;
+        $this->rights[$r][1] = 'Oxu';
+        $this->rights[$r][2] = 'r';
+        $this->rights[$r][3] = 0;
+        $this->rights[$r][4] = 'read';
+        $r++;
+        $this->rights[$r][0] = 5002;
+        $this->rights[$r][1] = 'Yaz';
+        $this->rights[$r][2] = 'w';
+        $this->rights[$r][3] = 0;
+        $this->rights[$r][4] = 'write';
+    }
+}

--- a/htdocs/custom/azaccounting/sql/azaccounting.sql
+++ b/htdocs/custom/azaccounting/sql/azaccounting.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS llx_az_employee (
+    rowid INTEGER AUTO_INCREMENT PRIMARY KEY,
+    ref VARCHAR(50),
+    lastname VARCHAR(50),
+    firstname VARCHAR(50),
+    position VARCHAR(100),
+    salary DOUBLE,
+    active TINYINT DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS llx_az_payroll (
+    rowid INTEGER AUTO_INCREMENT PRIMARY KEY,
+    fk_employee INTEGER,
+    pay_date DATE,
+    gross DOUBLE,
+    income_tax DOUBLE,
+    dsmf DOUBLE,
+    net DOUBLE
+);
+
+CREATE TABLE IF NOT EXISTS llx_az_taxconfig (
+    rowid INTEGER AUTO_INCREMENT PRIMARY KEY,
+    income_tax_rate DOUBLE,
+    dsmf_rate DOUBLE
+);


### PR DESCRIPTION
## Summary
- create AzAccounting custom module under `htdocs/custom`
- implement module descriptor and core classes for payroll and tax calculation
- add admin setup page and Azerbaijani language strings
- provide payroll form and listing pages
- document module in README and spec file

## Testing
- `php` not available, so syntax checks were skipped

------
https://chatgpt.com/codex/tasks/task_e_6852c2cd1c2c8324a9913fac0e1b5c02